### PR TITLE
Fixed emphasis section since highlighting and scientific notation wer…

### DIFF
--- a/notebook-getting-started/03-Markdown Cells.ipynb
+++ b/notebook-getting-started/03-Markdown Cells.ipynb
@@ -8,8 +8,7 @@
         "\n",
         "Markdown cells can be mixed with code cells to turn a notebook into a tutorial or just to give context for a seciton of code. For a complete set of Markdown documentation check out [markdownguide.org](https://www.markdownguide.org/) but we hope this cheat sheet will you get started.\n",
         "\n",
-        "Click the edit markdown button ![Edit Button](https://github.com/JakeRadMSFT/csharp-notebooks/raw/main/notebook-getting-started/images/edit%20markdown.png) to check out the syntax.\n",
-        ""
+        "Click the edit markdown button ![Edit Button](https://github.com/JakeRadMSFT/csharp-notebooks/raw/main/notebook-getting-started/images/edit%20markdown.png) to check out the syntax.\n"
       ]
     },
     {
@@ -54,10 +53,9 @@
         "This is a **bold text**.  \n",
         "This is *Italicized text*.  \n",
         "This is ~~strikethrough text~~.  \n",
-        "This is ==highlighted text==.  \n",
-        "This is water - H~2~0  \n",
-        "This is x * x - X^2^\n",
-        ""
+        "This is <mark>highlighted text</mark>.  \n",
+        "This is water - $H_2O$  \n",
+        "This is $x * x - x^2$\n"
       ]
     },
     {


### PR DESCRIPTION
I accidentally made a branch on the main repo as well, my apologies.

This pull request aims to fix the Emphasis section in the Markdown Cells.jpynb notebook.
Highlighting text was not working for me in VS Code or in Codespaces, nor was the scientific notation.
I've used the `<mark>` tag to highlight text and `LateX` markdown for the scientific notation.

As a bonus water is now actually 2 hydrogen atoms with an oxygen atom instead of 20 hydrogen atoms. It's safe to open the faucet again.