### PR TITLE
Modernized syntax, collection expressions and more explicitly typed variables

### DIFF
--- a/csharp-101/10-Arrays, Lists, and Collections.ipynb
+++ b/csharp-101/10-Arrays, Lists, and Collections.ipynb
@@ -23,6 +23,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -40,7 +43,7 @@
         "using System;\n",
         "using System.Collections.Generic;\n",
         "\n",
-        "var names = new List<string> { \"<name>\", \"Ana\", \"Felipe\" };\n",
+        "List<string> names = [ \"<name>\", \"Ana\", \"Felipe\" ];\n",
         "foreach (var name in names)\n",
         "{\n",
         "    Console.WriteLine($\"Hello {name.ToUpper()}!\");\n",
@@ -81,6 +84,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -98,7 +104,7 @@
         "using System;\n",
         "using System.Collections.Generic;\n",
         "\n",
-        "var names = new List<string> { \"<name>\", \"Ana\", \"Felipe\" };\n",
+        "List<string> names = [ \"<name>\", \"Ana\", \"Felipe\" ];\n",
         "for (int i = 0;i < names.Count; i++)\n",
         "{\n",
         "    Console.WriteLine($\"Hello {names[i].ToUpper()}\");\n",
@@ -123,6 +129,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -138,7 +147,7 @@
         }
       ],
       "source": [
-        "var names = new List<string> { \"<name>\", \"Ana\", \"Felipe\" };\n",
+        "List<string> names = [ \"<name>\", \"Ana\", \"Felipe\" ];\n",
         "\n",
         "names.Add(\"Sophia\");\n",
         "\n",
@@ -169,6 +178,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -182,7 +194,7 @@
         }
       ],
       "source": [
-        "var names = new List<string> { \"<name>\", \"Ana\", \"Felipe\" };\n",
+        "List<string> names = [ \"<name>\", \"Ana\", \"Felipe\" ];\n",
         "\n",
         "names.Remove(\"<name>\");\n",
         "\n",
@@ -212,6 +224,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -224,7 +239,7 @@
         }
       ],
       "source": [
-        "var names = new List<string> { \"<name>\", \"Sophia\", \"Felipe\" };\n",
+        "List<string> names = [ \"<name>\", \"Sophia\", \"Felipe\" ];\n",
         "Console.WriteLine(names[1]);"
       ]
     },
@@ -261,6 +276,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [

--- a/csharp-101/11- Search, Sort, and Index Lists.ipynb
+++ b/csharp-101/11- Search, Sort, and Index Lists.ipynb
@@ -30,6 +30,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -44,9 +47,11 @@
       "source": [
         "using System;\n",
         "using System.Collections.Generic;\n",
-        "var names = new List<string> { \"Sophia\", \"Ana\", \"Jayme\", \"Bill\" };\n",
+        "\n",
+        "List<string> names [ \"Sophia\", \"Ana\", \"Jayme\", \"Bill\" ];\n",
         "string name = \"Ana\";\n",
         "var index = names.IndexOf(name);\n",
+        "\n",
         "Console.WriteLine($\"Found {name} at {index}\");"
       ]
     },
@@ -69,6 +74,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -81,7 +89,7 @@
         }
       ],
       "source": [
-        "var names = new List<string> { \"Sophia\", \"Ana\", \"Jayme\", \"Bill\" };\n",
+        "List<string> names = [ \"Sophia\", \"Ana\", \"Jayme\", \"Bill\" ];\n",
         "string name = \"Scott\";\n",
         "var index = names.IndexOf(name);\n",
         "if(index == -1){\n",
@@ -112,6 +120,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -134,7 +145,7 @@
         }
       ],
       "source": [
-        "var names = new List<string> { \"Sophia\", \"Ana\", \"Jayme\", \"Bill\" };\n",
+        "List<string> names = [ \"Sophia\", \"Ana\", \"Jayme\", \"Bill\" ];\n",
         "Console.WriteLine(\"Pre Sorting:\");\n",
         "foreach(var name in names )\n",
         "{\n",
@@ -172,6 +183,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [

--- a/csharp-101/12-Lists of Other Types.ipynb
+++ b/csharp-101/12-Lists of Other Types.ipynb
@@ -28,6 +28,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -41,7 +44,7 @@
         }
       ],
       "source": [
-        "var fibonacciNumbers = new List<int> {1, 1};\n",
+        "List<int> fibonacciNumbers = [1, 1];\n",
         "\n",
         "foreach (var item in fibonacciNumbers)\n",
         "    Console.WriteLine(item);"
@@ -62,6 +65,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [
@@ -76,7 +82,7 @@
         }
       ],
       "source": [
-        "var fibonacciNumbers = new List<int> {1, 1}; // Starting the list off with the basics\n",
+        "List<int> fibonacciNumbers = [1, 1]; // Starting the list off with the basics\n",
         "\n",
         "var previous = fibonacciNumbers[fibonacciNumbers.Count - 1]; // Take the last number in the list\n",
         "var previous2 = fibonacciNumbers[fibonacciNumbers.Count - 2]; // Take the second to last number in the list\n",
@@ -113,6 +119,9 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
       "outputs": [

--- a/csharp-scenarios/01-Alien-Translator.ipynb
+++ b/csharp-scenarios/01-Alien-Translator.ipynb
@@ -64,20 +64,25 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
-      "source": [
-        "Console.WriteLine(\"Hi extraterrestrials, my name is myName.\");"
-      ],
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": "Hi extraterrestrials, my name is myName.\r\n"
+            "text/plain": [
+              "Hi extraterrestrials, my name is myName.\r\n"
+            ]
           },
           "execution_count": 1,
-          "metadata": {}
+          "metadata": {},
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "Console.WriteLine(\"Hi extraterrestrials, my name is myName.\");"
       ]
     },
     {
@@ -105,22 +110,27 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "myName studies language.\r\n"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "Console.WriteLine(\"Hi extraterrestrials, my name is myName.\"); \n",
         "Console.WriteLine(\"myName is a researcher.\"); \n",
         "Console.WriteLine(\"myName studies language.\"); "
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "myName studies language.\r\n"
-          },
-          "execution_count": 1,
-          "metadata": {}
-        }
       ]
     },
     {
@@ -141,25 +151,30 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
-      "source": [
-        "var phoneNumber = 123456789;\n",
-        "Console.WriteLine($\"For more help, please call {phoneNumber}\");"
-      ],
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": "For more help, please call 123456789\r\n"
+            "text/plain": [
+              "For more help, please call 123456789\r\n"
+            ]
           },
           "execution_count": 1,
-          "metadata": {}
+          "metadata": {},
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "int phoneNumber = 123456789;\n",
+        "Console.WriteLine($\"For more help, please call {phoneNumber}\");"
       ]
     },
     {
@@ -177,22 +192,27 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "myName studies language.\r\n"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "Console.WriteLine(\"Hi extraterrestrials, my name is myName.\"); \n",
         "Console.WriteLine(\"myName is a researcher.\"); \n",
         "Console.WriteLine(\"myName studies language.\"); "
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "myName studies language.\r\n"
-          },
-          "execution_count": 1,
-          "metadata": {}
-        }
       ]
     },
     {
@@ -221,8 +241,12 @@
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [],
       "source": [
         "string ToEnglish(string word) => word switch\n",
         "{\n",
@@ -247,8 +271,7 @@
         "    \"argsha\"    => \"spaceship\",\n",
         "    _           => \"Unknown\"\n",
         "};"
-      ],
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -276,29 +299,34 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "She is cool\r\n"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
-        "var stringName = \"He is cold\"; \n",
+        "string stringName = \"He is cold\"; \n",
         "\n",
         "// Below, we replace \"He\" with \"She\" and \"cold\" with \"cool\"\n",
         "stringName = stringName.Replace(\"He\", \"She\").Replace(\"cold\",\"cool\"); \n",
         "\n",
         "Console.WriteLine(stringName);"
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "She is cool\r\n"
-          },
-          "execution_count": 1,
-          "metadata": {}
-        }
       ]
     },
     {
@@ -312,31 +340,36 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Warshel abree yoish\r\n"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "// here’s the alien message \n",
         "\n",
-        "var message = \"Warshel abree yoish\";\n",
+        "string message = \"Warshel abree yoish\";\n",
         "\n",
         "// try replacing the words in language x with their English counterparts using the Replace method \n",
         "\n",
         "// print the message\n",
         "Console.WriteLine(message);"
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "Warshel abree yoish\r\n"
-          },
-          "execution_count": 1,
-          "metadata": {}
-        }
       ]
     },
     {
@@ -377,33 +410,38 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "example "
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
-        "var sentence = \"this is an example\";\n",
+        "string sentence = \"this is an example\";\n",
         "\n",
         "// split the string into substrings\n",
         "string[] variableCollection = sentence.Split(' ');\n",
         "\n",
-        "for(var i = 0; i < variableCollection.Length; i++) \n",
+        "for(int i = 0; i < variableCollection.Length; i++) \n",
         "{ \n",
         "     // statements to be executed \n",
         "     Console.Write(variableCollection[i] + \" \");\n",
         "} "
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "example "
-          },
-          "execution_count": 1,
-          "metadata": {}
-        }
       ]
     },
     {
@@ -417,37 +455,42 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "dotnet_interactive": {
           "language": "csharp"
+        },
+        "vscode": {
+          "languageId": "csharp"
         }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "yoish shwaye ni ceroyash yoish oppor shioy abree coierm veiesht shir shioy abree yoish\r\n"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
-        "var alienMessage = \"yoish shwaye ni ceroyash yoish oppor shioy abree coierm veiesht shir shioy abree yoish\"; \n",
+        "string alienMessage = \"yoish shwaye ni ceroyash yoish oppor shioy abree coierm veiesht shir shioy abree yoish\"; \n",
         "\n",
         "// split alienMessage into word substrings and store it in a variable called words \n",
         "string[] words = alienMessage.Split(' '); \n",
         "\n",
         "// Here is where we will loop through each word in words and translate them  \n",
-        "for(var i = 0; i < words.Length; i++) \n",
+        "for(int i = 0; i < words.Length; i++) \n",
         "{ \n",
         "\t// pass the word to the switch expression here \n",
         "}\n",
         "\n",
         "// turn the English word back into a string using the Join method\n",
-        "var englishMessage = string.Join(\" \", words);\n",
+        "string englishMessage = string.Join(\" \", words);\n",
         "Console.WriteLine(englishMessage);"
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "yoish shwaye ni ceroyash yoish oppor shioy abree coierm veiesht shir shioy abree yoish\r\n"
-          },
-          "execution_count": 1,
-          "metadata": {}
-        }
       ]
     },
     {


### PR DESCRIPTION
Pretty much what the title says:

```csharp
//original
var names = new List<string> { "Sophia", "Rob", "Michelle" };

//updated
List<string> names = [ "Sophia", "Rob", "Michelle" ];

//original
for (var i = 0; i < words.Length; i++)

//updated
for (int i = 0; i < words.Length; i++)
```

From notebook 10 onwards, in the C# 101 section, suddenly everything is instantiated with `var`. In my opinion, if you're going to do that, at least dedicate a section to explain the possibility to do that because it just seems to come out of nowhere and feels like a different person wrote those sections compared to the previous ones. I changed a few to explicitly typed where I thought it would be important for a beginner to know what they're looking at but I have left most as they were since it's a judgment call or style preference what is _"correct"_ there.